### PR TITLE
feat(rules): require-jsdoc, valid-jsdoc

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,45 @@ let array = [
 ];
 ```
 
+---
+
+#### 📍 require-jsdoc
+Requires JSDoc definitions for all functions and classes.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+methods: {
+    updateUser (id, data) {
+        return fetch(`/users/${id}`, {
+            method: 'POST',
+            body: JSON.stringify(opts),
+        });
+    },
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+methods: {
+    /**
+     * Update the user with the given id via the API
+     *
+     * @param {Number} id - id of user
+     * @param {Object} id - userdata object
+     *
+     * @returns {Promise} 
+     */
+    updateUser (id, data) {
+        return fetch(`/users/${id}`, {
+            method: 'POST',
+            body: JSON.stringify(opts),
+        });
+    },
+}
+```
+
 ### Vue
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -116,9 +116,9 @@ methods: {
      * Update the user with the given id via the API
      *
      * @param {Number} id - id of user
-     * @param {Object} id - userdata object
+     * @param {Object} data - userdata object
      *
-     * @returns {Promise} 
+     * @returns {Promise}
      */
     updateUser (id, data) {
         return fetch(`/users/${id}`, {

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -4,5 +4,17 @@ module.exports = {
     rules: {
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],
+        // Require JSDoc on all functions and classes
+        'require-jsdoc': [_THROW.WARNING, {
+            "require": {
+                "FunctionDeclaration": true,
+                "MethodDefinition": true,
+                "ClassDeclaration": true,
+                "ArrowFunctionExpression": true,
+                "FunctionExpression": true,
+            },
+        }],
+        // Require jsdoc data to be consistently valid
+        'valid-jsdoc': [_THROW.WARNING],
     },
 }


### PR DESCRIPTION
## Suggested rule(s): 
* `require-jsdoc` 
* `valid-jsdoc`

## Reason for addition
Properly documented functions make it easy to see what a function does, what it accepts and what it spits out the other end. 

Specifying these things make you think about the data I/O structure.

Allows IDEs (and other editors with intellisense) to intelligently determine types without using a typed language.

Ability to generate JS documentation - although probably not required for 99% of projects, it creates a base for the future.

