### PR TITLE
fix(jsdoc): Make JSDoc declarations less strict

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,45 @@ let array = [
 ];
 ```
 
+---
+
+#### 📍 require-jsdoc
+Requires JSDoc definitions for all functions and classes.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+methods: {
+    updateUser (id, data) {
+        return fetch(`/users/${id}`, {
+            method: 'POST',
+            body: JSON.stringify(opts),
+        });
+    },
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+methods: {
+    /**
+     * Update the user with the given id via the API
+     *
+     * @param {Number} id - id of user
+     * @param {Object} id - userdata object
+     *
+     * @returns {Promise} 
+     */
+    updateUser (id, data) {
+        return fetch(`/users/${id}`, {
+            method: 'POST',
+            body: JSON.stringify(opts),
+        });
+    },
+}
+```
+
 ### Vue
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -116,9 +116,9 @@ methods: {
      * Update the user with the given id via the API
      *
      * @param {Number} id - id of user
-     * @param {Object} id - userdata object
+     * @param {Object} data - userdata object
      *
-     * @returns {Promise} 
+     * @returns {Promise}
      */
     updateUser (id, data) {
         return fetch(`/users/${id}`, {

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -6,15 +6,20 @@ module.exports = {
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],
         // Require JSDoc on all functions and classes
         'require-jsdoc': [_THROW.WARNING, {
-            "require": {
-                "FunctionDeclaration": true,
-                "MethodDefinition": true,
-                "ClassDeclaration": true,
-                "ArrowFunctionExpression": true,
-                "FunctionExpression": true,
+            require: {
+                FunctionDeclaration: true,
+                MethodDefinition: true,
+                ClassDeclaration: true,
+                ArrowFunctionExpression: true,
+                FunctionExpression: true,
             },
         }],
         // Require jsdoc data to be consistently valid
-        'valid-jsdoc': [_THROW.WARNING],
+        'valid-jsdoc': [_THROW.WARNING, {
+            requireParamDescription: false.
+            requireReturnDescription: false,
+            matchDescription: ".+",
+            requireReturn: false,
+        }],
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -4,5 +4,17 @@ module.exports = {
     rules: {
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],
+        // Require JSDoc on all functions and classes
+        'require-jsdoc': [_THROW.WARNING, {
+            "require": {
+                "FunctionDeclaration": true,
+                "MethodDefinition": true,
+                "ClassDeclaration": true,
+                "ArrowFunctionExpression": true,
+                "FunctionExpression": true,
+            },
+        }],
+        // Require jsdoc data to be consistently valid
+        'valid-jsdoc': [_THROW.WARNING],
     },
 }

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -30,14 +30,14 @@ module.exports = {
             ],
             // Enforce 4 space continuous indentation
             'vue/html-indent': [_THROW.ERROR, 4, {
-                'attribute': 1,
-                'closeBracket': 0,
+                attribute: 1,
+                closeBracket: 0,
             }],
             // Force attributes to be hyphenated rather than camelCase
             'vue/attribute-hyphenation': [_THROW.ERROR, 'always'],
             // Disallow duplicate key names to avoid overwriting
             'vue/no-dupe-keys': [_THROW.ERROR, {
-                'groups': [],
+                groups: [],
             }],
             // Enforce the shorthand v-on: syntax (@)
             'vue/v-on-style': [_THROW.ERROR, 'shorthand'],


### PR DESCRIPTION
## Rules affected
* `require-jsdoc`
* `valid-jsdoc`

## Reason for change
Returned data does not need to be required if return is void, and a description is not required in most cases as it should be described in the method/function name.

Param descriptions not really necessary as should be self describing.

JSDoc descriptions are always required.