### PR TITLE
rule/add-func-names-never Disallows setting explicit function expression names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,7 +151,7 @@ Foo.prototype.bar = function foo(){
 ##### ✅ Example of correct code for this rule:
 
 ```js
-Foo.prototype.bar = function() {
+Foo.prototype.bar = () => {
     // ...
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,33 @@ methods: {
 }
 ```
 
+---
+
+#### 📍 func-names
+Disallows explicit function names.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+function foo(){
+    // ...
+}
+```
+
+```js
+Foo.prototype.bar = function foo(){
+    // ...
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+Foo.prototype.bar = function() {
+    // ...
+}
+```
+
 ### Vue
 
 ---

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -21,5 +21,6 @@ module.exports = {
             matchDescription: ".+",
             requireReturn: false,
         }],
+        'func-names': [_THROW.ERROR, 'never'],
     },
 }


### PR DESCRIPTION
## Suggested rule(s): 
* `func-names`

## Reason for addition
Forces all function expressions to be anonymous, as in arrow functions for promises, callbacks, etc.

Or functions must be assigned to a variable:

```
Foo.prototype.bar = () => {

}
```

This is to stop scope creep, making sure all functions are properly scoped and nothing is lurking in global scope.

Makes code neater by making modules more reusable by making all functions assigned accessible from the `module.exports`. 

Makes a transition to JS classes easier as everything should be in place because of the aforementioned scoping.
