### PR TITLE
Rule | no-mixed-spaces-and-tabs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,42 @@ let array = [
 
 ---
 
+#### 📍 no-mixed-spaces-and-tabs
+Disallow mixed spaces and tabs for indentation
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+
+function add(x, y) {
+// --->..return x + y;
+
+      return x + y;
+}
+
+function main() {
+// --->var x = 5,
+// --->....y = 7;
+
+    var x = 5,
+        y = 7;
+}
+
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+
+function add(x, y) {
+// --->return x + y;
+    return x + y;
+}
+
+```
+
+---
+
 #### 📍 require-jsdoc
 Requires JSDoc definitions for all functions and classes.
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -2,6 +2,8 @@ const _THROW = require('../modules/throwables');
 
 module.exports = {
     rules: {
+        //Disallow mixed spaces and tabs for indentation
+        'no-mixed-spaces-and-tabs': [_THROW.WARNING],
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],
         // Require JSDoc on all functions and classes

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -2,7 +2,7 @@ const _THROW = require('../modules/throwables');
 
 module.exports = {
     rules: {
-        //Disallow mixed spaces and tabs for indentation
+        // Disallow mixed spaces and tabs for indentation
         'no-mixed-spaces-and-tabs': [_THROW.WARNING],
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],


### PR DESCRIPTION
## Suggested rule/changes(s):
 * `no-mixed-spaces-and-tabs`  - Disallow mixed spaces and tabs for indentation
 
 ## Reason for addition/amendment
Most code conventions require either tabs or spaces be used for indentation. As such, it’s usually an error if a single line of code is indented with both tabs and spaces.

@netsells/frontend - Please review
 