### PR TITLE
Adds no-var rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -129,6 +129,31 @@ methods: {
 }
 ```
 
+#### 📍 no-var
+Discourages using `var` for creating variables and requires using `let` or `const` instead
+
+##### ❌ Example of incorrect code for this rule:
+
+```
+var count = posts.length;
+```
+
+##### ✅ Example of correct code for this rule:
+
+```
+const count = posts.length;
+```
+
+or, if the value can be changed
+
+```
+let count = posts.length;
+
+if (additionalPosts.length) {
+   count += additionalPosts.length;
+}
+```
+
 ### Vue
 
 ---

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -22,6 +22,6 @@ module.exports = {
             requireReturn: false,
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
-        'no-var': _THROW.WARNING,
+        'no-var': _THROW.ERROR,
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -21,5 +21,7 @@ module.exports = {
             matchDescription: ".+",
             requireReturn: false,
         }],
+        // Discourage using 'var' for creating variables - require using let/const instead
+        'no-var': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `no-var` 

## Reason for addition/amendment
Discourages using `var` for creating variables and requires using `let` or `const` instead - this allows us to create variables with a block scope, just like in the most common languages. 

#### Examples 

Using `var` can lead to some weird mistakes (example from the eslint docs):
```
var count = people.length;
var enoughFood = count > sandwiches.length;

if (enoughFood) {
    var count = sandwiches.length; // accidentally overriding the count variable
    console.log("We have " + count + " sandwiches for everyone. Plenty for all!");
}

// our count variable is no longer accurate
console.log("We have " + count + " people and " + sandwiches.length + " sandwiches!");
```

Use `let` for variables if your variable is reassigned after the initial assignment
```
let value = 5;

if (multiply) {
    value = value * multiply;
}
```

Use `const` if your variable will never be reassigned (constant value)
```
const name = 'Wiktor';

console.log(`Hello, ${name}`);
```

As mentioned, these variables have a block scope, so the following won't work as planned
```
if (condition) {
    const name = 'Wiktor';
} else {
    const name = 'Anonymous';
}

// name is undefined, because it wasn't defined in our scope
console.log(`Hello ${name}`);
```

@netsells/frontend - Please review 