### PR TITLE
Arrow spacing rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,8 +47,6 @@ Add the loader into your workflow. The following example will force the linter t
 
 ### JavaScript
 
----
-
 #### 📍 comma-dangle
 Requires trailing commas when the last element or property is in a different line than the closing `]` or `}` and disallows trailing commas when the last element or property is on the same line as the closing `]` or `}`. This makes git diffs a lot cleaner with single line changes rather than two.
 
@@ -128,6 +126,30 @@ methods: {
     },
 }
 ```
+
+#### 📍 arrow-spacing
+
+Requires space before and after arrow functions
+
+##### ❌ Example of incorrect code for this rule:
+
+```
+(a)=>{};
+()=> {};
+() =>{};
+(a)=> {};
+(a) =>{};
+
+```
+
+##### ✅ Example of correct code for this rule:
+
+```
+(a) => {}
+
+```
+
+
 
 ### Vue
 

--- a/readme.md
+++ b/readme.md
@@ -167,10 +167,10 @@ methods: {
 Discourages using `var` for creating variables and requires using `let` or `const` instead
 
 ##### ❌ Example of incorrect code for this rule:
-`var count = posts.length;`
+```var count = posts.length;```
 
 ##### ✅ Example of correct code for this rule:
-`const count = posts.length;`
+```const count = posts.length;```
 
 or, if the value can be changed
 
@@ -193,15 +193,12 @@ arrows on arrow functions should have a space before and after.
 () =>{};
 (a)=> {};
 (a) =>{};
-
 ```
 
 ##### ✅ Example of correct code for this rule:
 
 ```
-
 (a) => {}
-
 ```
 
 ### Vue

--- a/readme.md
+++ b/readme.md
@@ -167,10 +167,14 @@ methods: {
 Discourages using `var` for creating variables and requires using `let` or `const` instead
 
 ##### ❌ Example of incorrect code for this rule:
-```var count = posts.length;```
+```
+var count = posts.length;
+```
 
 ##### ✅ Example of correct code for this rule:
-```const count = posts.length;```
+```
+const count = posts.length;
+```
 
 or, if the value can be changed
 

--- a/readme.md
+++ b/readme.md
@@ -167,10 +167,10 @@ methods: {
 Discourages using `var` for creating variables and requires using `let` or `const` instead
 
 ##### ❌ Example of incorrect code for this rule:
-`var count = posts.length;
+`var count = posts.length;`
 
 ##### ✅ Example of correct code for this rule:
-`const count = posts.length;
+`const count = posts.length;`
 
 or, if the value can be changed
 

--- a/readme.md
+++ b/readme.md
@@ -163,42 +163,14 @@ methods: {
 }
 ```
 
-<<<<<<< HEAD
-#### 📍 arrow-spacing
-
-Requires space before and after arrow functions
-=======
 #### 📍 no-var
 Discourages using `var` for creating variables and requires using `let` or `const` instead
->>>>>>> master
 
 ##### ❌ Example of incorrect code for this rule:
-
-```
-<<<<<<< HEAD
-(a)=>{};
-()=> {};
-() =>{};
-(a)=> {};
-(a) =>{};
-
-=======
-var count = posts.length;
->>>>>>> master
-```
+`var count = posts.length;
 
 ##### ✅ Example of correct code for this rule:
-
-```
-<<<<<<< HEAD
-(a) => {}
-
-```
-
-
-=======
-const count = posts.length;
-```
+`const count = posts.length;
 
 or, if the value can be changed
 
@@ -209,7 +181,28 @@ if (additionalPosts.length) {
    count += additionalPosts.length;
 }
 ```
->>>>>>> master
+
+#### 📍 arrow-spacing
+arrows on arrow functions should have a space before and after.
+
+##### ❌ Example of incorrect code for this rule:
+
+```
+(a)=>{};
+()=> {};
+() =>{};
+(a)=> {};
+(a) =>{};
+
+```
+
+##### ✅ Example of correct code for this rule:
+
+```
+
+(a) => {}
+
+```
 
 ### Vue
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -21,7 +21,10 @@ module.exports = {
             matchDescription: ".+",
             requireReturn: false,
         }],
-        // 
-        'arrow-spacing': [_THROW.ERROR, {before: true, after: true}],
+        // Requires spacing before and after arrow functions arrow
+        'arrow-spacing': [_THROW.WARNING, {
+            before: true,
+            after: true,
+        }],
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -40,7 +40,6 @@ module.exports = {
             matchDescription: ".+",
             requireReturn: false,
         }],
-
         // Requires spacing before and after arrow functions arrow
         'arrow-spacing': [_THROW.WARNING, {
             before: true,

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -21,5 +21,7 @@ module.exports = {
             matchDescription: ".+",
             requireReturn: false,
         }],
+        // 
+        'arrow-spacing': [_THROW.ERROR, {before: true, after: true}],
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -46,7 +46,6 @@ module.exports = {
             before: true,
             after: true,
         }],
-
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
         // Throw a warning when a regular string contains a text which looks like a template literal placeholder


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<arrow-spacing>` 

## Reason for addition/amendment

Before and after the arrow function's arrow, should always include spacing. 
for example: (a) => {}.

Both before and after should be set as true.
{ "before": true, "after": true }.

This helps the code to be more readable.

Feel free to include code samples if it's a new rule.

@netsells/frontend - Please review 