### PR TITLE
Adds ‘no-unused-vars’ rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -730,6 +730,40 @@ export default {
 }
 ```
 
+--
+
+#### 📍 no-unused-vars
+
+`@throws Error`
+
+All imports and vars that are included within code must be used.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+let foo = 'bar';
+
+function fooBar() {
+    //code
+}
+
+//End of file
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+let foo = 'bar';
+
+function fooBar() {
+    return `${foo}bar`;
+    
+    //code
+}
+
+//End of file
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/readme.md
+++ b/readme.md
@@ -734,7 +734,7 @@ export default {
 
 #### 📍 no-unused-vars
 
-`@throws Error`
+`@throws Warning`
 
 All imports and vars that are included within code must be used.
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,7 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        // Prevents leaving unused imports & vars in code
+        'no-unused-vars': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-unused-vars>` 

## Reason for addition/amendment
> Rule will throw a warning if an unused variable is left within the code (either an import, var, let or const).
> No point in leaving them in and neatens up the code base if they are all removed from the files.

@netsells/frontend - Please review 