### PR TITLE
Rule/no eval

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,13 +135,13 @@ Disallow eval() function
 
 ```js
 
-var obj = { x: "foo" },
+let obj = { x: 'foo' },
     key = "x",
     value = eval("obj." + key);
 
 (0, eval)("var a = 0");
 
-var foo = eval;
+let foo = eval;
 foo("var a = 0");
 
 // This `this` is the global object.
@@ -157,7 +157,7 @@ global.eval("var a = 0");
 
 ```js
 
-var obj = { x: "foo" },
+let obj = { x: 'foo' },
     key = "x",
     value = obj[key];
 
@@ -168,7 +168,7 @@ class A {
     }
 
     eval() {
-        
+
     }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,54 @@ function add(x, y) {
 
 ---
 
+#### 📍 no-eval
+Disallow eval() function
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+
+var obj = { x: "foo" },
+    key = "x",
+    value = eval("obj." + key);
+
+(0, eval)("var a = 0");
+
+var foo = eval;
+foo("var a = 0");
+
+// This `this` is the global object.
+this.eval("var a = 0");
+
+window.eval("var a = 0");
+
+global.eval("var a = 0");
+
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+
+var obj = { x: "foo" },
+    key = "x",
+    value = obj[key];
+
+class A {
+    foo() {
+        // This is a user-defined method.
+        this.eval("var a = 0");
+    }
+
+    eval() {
+        
+    }
+}
+
+```
+
+---
+
 #### 📍 require-jsdoc
 Requires JSDoc definitions for all functions and classes.
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -2,6 +2,8 @@ const _THROW = require('../modules/throwables');
 
 module.exports = {
     rules: {
+        // Disallow the use of the eval() function
+        'no-eval': [_THROW.ERROR],
         // Disallow mixed spaces and tabs for indentation
         'no-mixed-spaces-and-tabs': [_THROW.WARNING],
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no eval>` 

## Reason for addition/amendment
>* eval() function is potentially dangerous and is often misused. Using eval() on untrusted code can open a program up to several different injection attacks. The use of eval() in most contexts can be substituted for a better, alternative approach to a problem.
>* This rule is aimed at preventing potentially dangerous, unnecessary, and slow code by disallowing the use of the eval() function. As such, it will warn whenever the eval() function is used.


@netsells/frontend - Please review 