### PR TITLE
rule/new-jsdoc-require-except Adds ability to except requiring JS docs for certain methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,4 +10,7 @@ module.exports = {
     env: { 
         es6: true,
     },
+    plugins: [
+        'require-jsdoc-except',
+    ]
 };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "eslint": "^4.10.0",
+    "eslint-plugin-require-jsdoc-except": "^1.1.0",
     "eslint-plugin-vue": "^3.13.1"
   }
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -7,7 +7,7 @@ module.exports = {
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],
         // Require JSDoc on all functions and classes
-        'require-jsdoc': [_THROW.WARNING, {
+        'require-jsdoc-except/require-jsdoc': [_THROW.WARNING, {
             require: {
                 FunctionDeclaration: true,
                 MethodDefinition: true,
@@ -15,6 +15,18 @@ module.exports = {
                 ArrowFunctionExpression: true,
                 FunctionExpression: true,
             },
+            // Ignore all the standard VueJS lifecycle methods
+            ignore: [
+                'beforeCreate',
+                'created',
+                'beforeMount',
+                'mounted',
+                'beforeDestroy',
+                'destroyed',
+                'beforeUpdate',
+                'updated',
+                'data',
+            ],
         }],
         // Require jsdoc data to be consistently valid
         'valid-jsdoc': [_THROW.WARNING, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -203,6 +203,13 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-plugin-require-jsdoc-except@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-require-jsdoc-except/-/eslint-plugin-require-jsdoc-except-1.1.0.tgz#380a5987917010fa53d34ab6b4dc2db8cadd19f5"
+  dependencies:
+    lodash.assignin "^4.2.0"
+    lodash.get "^4.4.2"
+
 eslint-plugin-vue@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-3.13.1.tgz#875dc47a90c2e4034013b6ce1b915e5a5c6e9bf9"
@@ -496,6 +503,14 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lodash.assignin@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
 lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"


### PR DESCRIPTION
## Suggested rule/changes(s):
* `require-jsdoc-except` 

## Reason for addition/amendment
This allows you to exclude certain method names from linting. Useful for say Vue components as it will stop requiring every lifecycle method of every `.vue` file to have a JSDoc.

@netsells/frontend - Please review 