### PR TITLE
add no-empty rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -92,6 +92,56 @@ let array = [
 
 ---
 
+#### 📍 no-empty
+disallow empty block statements
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+if (foo) {
+}
+
+while (foo) {
+}
+
+switch(foo) {
+}
+
+try {
+    doSomething();
+} catch(ex) {
+
+} finally {
+
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+if (foo) {
+    // empty
+}
+
+while (foo) {
+    /* empty */
+}
+
+try {
+    doSomething();
+} catch (ex) {
+    // continue regardless of error
+}
+
+try {
+    doSomething();
+} finally {
+    /* continue regardless of error */
+}
+```
+
+---
+
 #### 📍 no-mixed-spaces-and-tabs
 Disallow mixed spaces and tabs for indentation
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -4,7 +4,7 @@ module.exports = {
     rules: {
         // Disallow mixed spaces and tabs for indentation
         'no-mixed-spaces-and-tabs': [_THROW.WARNING],
-        // disallow empty block statements
+        // Disallow empty block statements
         'no-empty': _THROW.WARNING,
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -4,6 +4,8 @@ module.exports = {
     rules: {
         // Disallow mixed spaces and tabs for indentation
         'no-mixed-spaces-and-tabs': [_THROW.WARNING],
+        // disallow empty block statements
+        'no-empty': _THROW.WARNING,
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'only-multiline'],
         // Require JSDoc on all functions and classes


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-empty>` 

## Reason for addition/amendment
Empty block statements, while not technically errors, usually occur due to refactoring that wasn’t completed. They can cause confusion when reading code.

*There is an additional option available called `allowEmptyCatch` which, as the name suggests, allows empty catch clauses. this was not included as I believe we should be actually doing something when erroring rather than ignoring it. *

closes #30 


@netsells/frontend - Please review 