### PR TITLE
Adds curly rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -730,6 +730,46 @@ export default {
 }
 ```
 
+--
+
+#### 📍 curly
+
+`@throws Warning`
+
+Curly brace conventions must follow a strict formatted pattern.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+if (foo) return;
+
+while (bar)
+    baz();
+
+if (foo) {
+    baz();
+} else qux();
+
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+if (foo) {
+    return;
+}
+
+while (bar) {
+    baz();
+}
+
+if (foo) {
+    baz();
+} else {
+    qux();
+}
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,7 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        // Forces formatting of curly brace conventions
+        'curly': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<curly>` 

## Reason for addition/amendment
> Closes #23 
> Forces curly brace convention thorough-out code to keep everything consistent.
> Follows format voted for in #team-frontend
> See readme.md for code examples.

@netsells/frontend - Please review 