### PR TITLE
rule/add-no-implicit-coercion Adds rules to stop mixing variable types

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,16 +199,16 @@ Encourages stopping mixing different types of variables for the sake of cleaner 
 ```
 // Boolean
 const b = !!foo;
-const b = ~foo.indexOf(".");
+const b = ~foo.indexOf('.');
 
 // Number
 const n = +foo;
 const n = 1 * foo;
 
 // Strings
-const s = "" + foo;
+const s = '' + foo;
 const s = `` + foo;
-foo += "";
+foo += '';
 foo += ``;
 
 ```
@@ -218,7 +218,7 @@ foo += ``;
 ```
 // Boolean
 const b = Boolean(foo);
-const b = foo.indexOf(".") !== -1;
+const b = foo.indexOf('.') !== -1;
 
 // Number
 const n = Number(foo);
@@ -228,16 +228,6 @@ const n = parseInt(foo, 10);
 // Strings
 const s = String(foo);
 foo = String(foo);
-```
-
-or, if the value can be changed
-
-```
-let count = posts.length;
-
-if (additionalPosts.length) {
-   count += additionalPosts.length;
-}
 ```
 
 ### Vue

--- a/readme.md
+++ b/readme.md
@@ -218,7 +218,7 @@ foo += ``;
 ```
 // Boolean
 const b = Boolean(foo);
-const b = foo.indexOf('.') !== -1;
+const b = foo.includes('.');
 
 // Number
 const n = Number(foo);

--- a/readme.md
+++ b/readme.md
@@ -354,7 +354,7 @@ Encourages stopping mixing different types of variables for the sake of cleaner 
 
 ##### ❌ Example of incorrect code for this rule:
 
-```
+```js
 // Boolean
 const b = !!foo;
 const b = ~foo.indexOf('.');

--- a/readme.md
+++ b/readme.md
@@ -198,16 +198,16 @@ Encourages stopping mixing different types of variables for the sake of cleaner 
 
 ```
 // Boolean
-var b = !!foo;
-var b = ~foo.indexOf(".");
+const b = !!foo;
+const b = ~foo.indexOf(".");
 
 // Number
-var n = +foo;
-var n = 1 * foo;
+const n = +foo;
+const n = 1 * foo;
 
 // Strings
-var s = "" + foo;
-var s = `` + foo;
+const s = "" + foo;
+const s = `` + foo;
 foo += "";
 foo += ``;
 
@@ -217,16 +217,16 @@ foo += ``;
 
 ```
 // Boolean
-var b = Boolean(foo);
-var b = foo.indexOf(".") !== -1;
+const b = Boolean(foo);
+const b = foo.indexOf(".") !== -1;
 
 // Number
-var n = Number(foo);
-var n = parseFloat(foo);
-var n = parseInt(foo, 10);
+const n = Number(foo);
+const n = parseFloat(foo);
+const n = parseInt(foo, 10);
 
 // Strings
-var s = String(foo);
+const s = String(foo);
 foo = String(foo);
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,56 @@ if (additionalPosts.length) {
 }
 ```
 
+
+#### 📍 no-implicit-coercion
+Encourages stopping mixing different types of variables for the sake of cleaner and more readable code.
+
+##### ❌ Example of incorrect code for this rule:
+
+```
+// Boolean
+var b = !!foo;
+var b = ~foo.indexOf(".");
+
+// Number
+var n = +foo;
+var n = 1 * foo;
+
+// Strings
+var s = "" + foo;
+var s = `` + foo;
+foo += "";
+foo += ``;
+
+```
+
+##### ✅ Example of correct code for this rule:
+
+```
+// Boolean
+var b = Boolean(foo);
+var b = foo.indexOf(".") !== -1;
+
+// Number
+var n = Number(foo);
+var n = parseFloat(foo);
+var n = parseInt(foo, 10);
+
+// Strings
+var s = String(foo);
+foo = String(foo);
+```
+
+or, if the value can be changed
+
+```
+let count = posts.length;
+
+if (additionalPosts.length) {
+   count += additionalPosts.length;
+}
+```
+
 ### Vue
 
 ---

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -47,6 +47,7 @@ module.exports = {
             boolean: true,
             number: true,
             string: true,
+        }],
         // Disallow else blocks after return statements in if statements
         'no-else-return': [_THROW.WARNING, {
             allowElseIf: false,

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,6 +25,7 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        // Discourage using confusing and sometimes unreadable JS tricks to do simple functions.
         'no-implicit-coercion': [_THROW.WARNING, {
             boolean: true,
             number: true,

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,10 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        'no-implicit-coercion': {
+            "boolean": true,
+            "number": true,
+            "string": true,
+        } 
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -26,9 +26,9 @@ module.exports = {
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
         'no-implicit-coercion': [_THROW.WARNING, {
-            "boolean": true,
-            "number": true,
-            "string": true,
+            boolean: true,
+            number: true,
+            string: true,
         }],
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,10 +25,10 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
-        'no-implicit-coercion': {
+        'no-implicit-coercion': [_THROW.WARNING, {
             "boolean": true,
             "number": true,
             "string": true,
-        } 
+        }],
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `no-implicit-coercion` 

## Reason for addition/amendment
This essentially warns you about mixing variable types, or using crazy tricks to get answers which may be cool and shave a few characters off here and there - but makes it hard to read and understand.

This could potentially change how certain things are done and we may have to collectively decide whether or not to fully implement this rule, or what we want or don't want as this could potentially get quite strict.

Closes #42 

@netsells/frontend - Please review 