### PR TITLE
Adds eqeqeq rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -730,6 +730,46 @@ export default {
 }
 ```
 
+--
+
+#### 📍 eqeqeq
+
+`@throws Warning`
+
+Equality operators must now be type-safe - as is considered best practice in coding.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+if (x == y) {
+    // code
+}
+
+if ("" == text) {
+    //code
+}
+
+if (obj.stuff != undefined) {
+    // code
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+if (x === y) {
+    // code
+}
+
+if ("" === text) {
+    // code
+}
+
+if (obj.stuff !== undefined) {
+    // code
+}
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,7 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        // Forces equality operators to be type-safe
+        'eqeqeq': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<eqeqeq>` 

## Reason for addition/amendment
> Closes #26 
> Forces equality operators to be type-safe instead of regular counterparts
> E.g. '===' instead of '==' or '!==' instead of '!='

@netsells/frontend - Please review 