### PR TITLE
rule/add-dot-notation Adds dot notation to rules

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,25 @@ if (additionalPosts.length) {
 }
 ```
 
+#### 📍 dot-notation
+Forces using dot notation exclusively for getting object properties.
+
+##### ❌ Example of incorrect code for this rule:
+
+```
+const a = foo["bar"];
+```
+
+##### ✅ Example of correct code for this rule:
+
+```
+const a = foo.bar;
+
+const b = "Hello";
+const c = foo[b];
+```
+
+
 ### Vue
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -196,7 +196,7 @@ Forces using dot notation exclusively for getting object properties.
 ##### ❌ Example of incorrect code for this rule:
 
 ```
-const a = foo["bar"];
+const a = foo['bar'];
 ```
 
 ##### ✅ Example of correct code for this rule:
@@ -204,7 +204,7 @@ const a = foo["bar"];
 ```
 const a = foo.bar;
 
-const b = "Hello";
+const b = 'Hello';
 const c = foo[b];
 ```
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -26,7 +26,7 @@ module.exports = {
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
         'dot-notation': [_THROW.WARNING, {
-            "allowKeywords": false,
+            allowKeywords: false,
         }]
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,8 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        'dot-notation': [_THROW.WARNING, {
+            "allowKeywords": false,
+        }]
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `dot-notation` 

## Reason for addition/amendment
Forces using dot notation or bracket notation with variables for getting object properties rather than being able to do

```
foo["bar"]
```

Closes #25 

@netsells/frontend - Please review 