### PR TITLE
Adds no-else-return rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -755,7 +755,7 @@ function foo() {
 ##### ✅ Example of correct code for this rule:
 
 ```js
-function  foo() {
+function foo() {
     if (x) {
         return a;
     }

--- a/readme.md
+++ b/readme.md
@@ -730,6 +730,44 @@ export default {
 }
 ```
 
+--
+
+#### 📍 no-else-return
+
+`@throws Warning`
+
+Prevents a return statement being called _before_ an else. But also, in this instance, as we have allowElseIf set to false, else statements will also _not_ be allowed in code.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+function foo() {
+    if (x) {
+        return a;
+    } else if (y) {
+        return b;
+    } else {
+        return c;
+    }
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+function  foo() {
+    if (x) {
+        return a;
+    }
+    
+    if (y) {
+        return b;   
+    }
+    
+    return c;
+}
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,8 +25,9 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        // Disallow else blocks after return statements in if statements
         'no-else-return': [_THROW.WARNING, {
             allowElseIf: false,
-        }]
+        }],
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,8 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        'no-else-return': [_THROW.WARNING, {
+            allowElseIf: false,
+        }]
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-else-return>` 

## Reason for addition/amendment
* Closes #29 
* Disallows return statements prior to an else if or else statement
* See examples of code in readme.md
* Also doesn't allow else statements - sorry boys!

@netsells/frontend - Please review 