### PR TITLE
Adds no-template-curly-in-string rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,23 @@ if (additionalPosts.length) {
 }
 ```
 
+#### 📍 
+
+Throw a warning when a regular string contains a text which looks like an ES6 template literal placeholder
+
+##### ❌ Example of incorrect code for this rule:
+
+```
+const greeting = "Hello, ${name}";
+```
+
+##### ✅ Example of correct code for this rule:
+
+```
+const greeting = `Hello, ${name}`;
+```
+
+
 ### Vue
 
 ---

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,7 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        // Throw a warning when a regular string contains a text which looks like a template literal placeholder
+        'no-template-curly-in-string': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-template-curly-in-string>` 

## Reason for addition/amendment
It throws a warning when a regular string contains a text which looks like a template literal placeholder.

Basically will throw a warning if that happens:
```
const greeting = 'Hello ${name}';
```

@netsells/frontend - Please review 