### PR TITLE
Adds prefer-template rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,23 @@ if (additionalPosts.length) {
 }
 ```
 
+#### 📍 prefer-template
+
+Encourage using template literals instead of '+' operator on strings
+
+##### ❌ Example of incorrect code for this rule:
+
+```
+const greeting = 'Hello, ' + this.name;
+```
+
+##### ✅ Example of correct code for this rule:
+
+```
+const greeting = `Hello, ${this.name}`;
+```
+
+
 ### Vue
 
 ---

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,5 +25,7 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
+        // Encourage using template literals instead of '+' operator on strings
+        'prefer-template': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<prefer-template>` 

## Reason for addition/amendment
Throws a warning if there's a '+' operator used on a string - template literals are preferred.

@netsells/frontend - Please review 