### PR TITLE
change comma dangle rule

### DIFF
--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -10,7 +10,7 @@ module.exports = {
         // Disallow empty block statements
         'no-empty': _THROW.WARNING,
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
-        'comma-dangle': [_THROW.ERROR, 'only-multiline'],
+        'comma-dangle': [_THROW.ERROR, 'always-multiline'],
         // Require JSDoc on all functions and classes
         'require-jsdoc-except/require-jsdoc': [_THROW.WARNING, {
             require: {


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<comma-dangle>` : `ERROR`

## Reason for addition/amendment
changed to `always-multiline` from `only-multiline`. 

before change the following was valid:
```
    const foobar = {
        foo,
        bar
    }
```


@netsells/frontend - Please review 