### PR TITLE
remove allowKeywords: false property from dot notation

### DIFF
--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -47,9 +47,7 @@ module.exports = {
         }],
         // Discourage using 'var' for creating variables - require using let/const instead
         'no-var': _THROW.ERROR,
-        'dot-notation': [_THROW.WARNING, {
-            allowKeywords: false,
-        }],
+        'dot-notation': _THROW.WARNING,
         // Discourage using confusing and sometimes unreadable JS tricks to do simple functions.
         'no-implicit-coercion': [_THROW.WARNING, {
             boolean: true,


### PR DESCRIPTION
## Suggested rule/changes(s):
* `dot-notation` : `__THROW.WARNING`

## Reason for addition/amendment
currently has issues when dealing with promise catches


@netsells/frontend - Please review 