### PR TITLE
add no-floating-decimal rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1119,7 +1119,35 @@ function foo() {
 }
 ```
 
---
+---
+
+#### 📍 no-floating-decimal
+
+`@throws Warning`
+
+Prevents using floating decimals
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+
+const num = .5;
+const ber = 2.;
+const wang = -.7;
+
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+
+const num = 0.5;
+const ber = 2.0;
+const wang = -0.7;
+
+```
+
+---
 
 #### 📍 curly
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -70,6 +70,8 @@ module.exports = {
         }],
         // Discourage placing the dot on the property rather than the property
         'dot-location': [_THROW.WARNING, 'property'],
+        // disallow floating decimals. Cause they're disgusting!
+        'no-floating-decimal': _THROW.ERROR,
         // Forces formatting of curly brace conventions
         'curly': _THROW.WARNING,
         // Encourage using template literals instead of '+' operator on strings


### PR DESCRIPTION
## Suggested rule/changes(s):
* `no-floating-decimal` : `ERROR`

## Reason for addition/amendment
floating decimals are disgusting. 

.2 = bad
0.2 =good

@netsells/frontend - Please review 