### PR TITLE
Disallow empty functions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,69 @@ try {
 
 ---
 
+#### 📍 no-empty-function
+Disallow empty functions
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+function foo () {}
+
+let foo = function () {};
+
+let foo = () => {};
+
+let obj = {
+    foo: function () {},
+
+    foo () {},
+};
+
+class A {
+    constructor() {}
+
+    foo() {}
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+function foo () {
+    // do nothing.
+}
+
+let foo = function () {
+    // any clear comments.
+};
+
+let foo = () => {
+    bar();
+};
+
+let obj = {
+    foo: function () {
+        // do nothing.
+    },
+
+    foo () {
+        // do nothing.
+    },
+};
+
+class A {
+    constructor () {
+        // do nothing.
+    }
+
+    foo () {
+        // do nothing.
+    }
+}
+```
+
+---
+
 #### 📍 no-mixed-spaces-and-tabs
 Disallow mixed spaces and tabs for indentation
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -9,6 +9,8 @@ module.exports = {
         'no-mixed-spaces-and-tabs': [_THROW.WARNING],
         // Disallow empty block statements
         'no-empty': _THROW.WARNING,
+        // Disallow empty functions
+        'no-empty-function': _THROW.WARNING,
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'always-multiline'],
         // Require JSDoc on all functions and classes


### PR DESCRIPTION
## Suggested rule/changes(s):
* `no-empty-function` : `WARNING`

## Reason for addition/amendment
>*Empty functions can reduce readability because readers need to guess whether it’s intentional or not. So writing a clear comment for empty functions is a good practice.

@netsells/frontend - Please review 