### PR TITLE
Require a space before function parenthesis 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,6 +159,63 @@ try {
 
 ---
 
+#### 📍 space-before-function-paren
+Require a space before function parenthesis
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+
+function foo() {
+    // ...
+}
+
+let bar = function() {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+let foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async() => 1
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+function foo () {
+    // ...
+}
+
+let bar = function () {
+    // ...
+};
+
+class Foo {
+    constructor () {
+        // ...
+    }
+}
+
+let foo = {
+    bar () {
+        // ...
+    }
+};
+
+var foo = async () => 1
+```
+
+---
 #### 📍 no-mixed-spaces-and-tabs
 Disallow mixed spaces and tabs for indentation
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -9,6 +9,8 @@ module.exports = {
         'no-mixed-spaces-and-tabs': [_THROW.WARNING],
         // Disallow empty block statements
         'no-empty': _THROW.WARNING,
+        // Require a space before function parenthesis 
+        'space-before-function-paren': _THROW.WARNING,
         // Requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }
         'comma-dangle': [_THROW.ERROR, 'always-multiline'],
         // Require JSDoc on all functions and classes


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<space-before-function-paren>` : `WARNING`

## Reason for addition/amendment
>This rule aims to enforce consistent spacing before function parentheses and as such, will warn whenever whitespace doesn’t match the preferences specified.

@netsells/frontend - Please review 