### PR TITLE
No lonely if rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1159,6 +1159,42 @@ if (foo) {
 }
 ```
 
+#### 📍 no-lonely-if
+
+`@throws Warning`
+
+If an if statement is the only statement in the else block, it is clearer to use an else if.
+
+##### ❌ Example of incorrect code for this rule:
+
+```if (foo) {
+    // ...
+} else {
+    if (bar) {
+        // ...
+    }
+}
+
+if (condition) {
+    // ...
+} else {
+    if (anotherCondition) {
+        // ...
+    }
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```if (condition) {
+    // ...
+} else if (anotherCondition) {
+    // ...
+} else {
+    // ...
+}
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/readme.md
+++ b/readme.md
@@ -1167,7 +1167,8 @@ If an if statement is the only statement in the else block, it is clearer to use
 
 ##### ❌ Example of incorrect code for this rule:
 
-```if (foo) {
+```js
+if (foo) {
     // ...
 } else {
     if (bar) {
@@ -1186,7 +1187,8 @@ if (condition) {
 
 ##### ✅ Example of correct code for this rule:
 
-```if (condition) {
+```js
+if (condition) {
     // ...
 } else if (anotherCondition) {
     // ...

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -74,5 +74,7 @@ module.exports = {
         'curly': _THROW.WARNING,
         // Encourage using template literals instead of '+' operator on strings
         'prefer-template': _THROW.WARNING,
+        //  discourage if statements as the only statement in else blocks
+        'no-lonely-if': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-lonely-if>` : `severity: (WARNING)`

## Reason for addition/amendment
* I doubt none of you guys do this anyways, but there shouldn't be an if statement in an else block, instead we should use else if. e.g 
```js
if (foo) {
    // ...
} else if (bar) {
    // ...
}
```

not

```js
if (foo) {
    // ...
} else {
   if (bar) {
        // ...
    }
}
```

@netsells/frontend - Please review 