### PR TITLE
Adds prefer-arrow-callback rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1158,6 +1158,37 @@ if (foo) {
     qux();
 }
 ```
+--
+
+#### 📍 prefer-arrow-callback
+
+`@throws Error`
+
+Forces user to use ES6 arrow function expressions
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+foo(function(a) { 
+    return a; 
+});
+
+foo(function() { 
+    return this.a; 
+}.bind(this));
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+foo((a) => {
+    return a;
+});
+
+foo(() => {
+    return this.a;
+});
+```
 
 ## Contributing
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -74,6 +74,7 @@ module.exports = {
         'curly': _THROW.WARNING,
         // Encourage using template literals instead of '+' operator on strings
         'prefer-template': _THROW.WARNING,
+        // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -74,5 +74,6 @@ module.exports = {
         'curly': _THROW.WARNING,
         // Encourage using template literals instead of '+' operator on strings
         'prefer-template': _THROW.WARNING,
+        'prefer-arrow-callback': _THROW.ERROR,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<prefer-arrow-callback>` : `severity: (ERROR)`

## Reason for addition/amendment
> Forces user to use ES6 arrow function expressions.
> See readme for examples of allowed and disallowed code.

@netsells/frontend - Please review 