### PR TITLE
Disallow duplicate imports (no-duplicate-imports)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -599,6 +599,27 @@ const c = foo[b];
 
 ---
 
+#### 📍 no-duplicate-imports
+
+Disallow duplicate imports.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+import { merge } from 'module';
+import something from 'another-module';
+import { find } from 'module';
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+import { merge, find } from 'module';
+import something from 'another-module';
+```
+
+---
+
 ### Vue
 
 ---

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -89,5 +89,7 @@ module.exports = {
         'no-cond-assign': _THROW.WARNING,
         // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
+        // Disallow duplicate imports
+        'no-duplicate-imports':  _THROW.WARNING,
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -90,6 +90,6 @@ module.exports = {
         // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
         // Disallow duplicate imports
-        'no-duplicate-imports':  _THROW.WARNING,
+        'no-duplicate-imports': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-duplicate-imports>` : `severity: WARNING`

## Reason for addition/amendment
>Using a single import statement per module will make the code clearer because you can see everything being imported from that module on one line.

@netsells/frontend - Please review 