### PR TITLE
CamelCase rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1443,6 +1443,36 @@ if (condition) {
     // ...
 }
 ```
+#### 📍 camelcase
+
+`@throws Warning`
+
+The rule looks for any _ located in your code in the middle of your variable names and will throw a warning. CamelCase should be used instead.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+let my_favorite_color = "#112C85";
+
+function do_something() {
+    // ...
+}
+
+let obj = {
+    my_pref: 1
+};
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+let myFavoriteColor   = "#112C85";
+
+function foo({ isCamelCased }) {
+    // ...
+};
+```
+
 
 ## Contributing
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -89,5 +89,7 @@ module.exports = {
         'no-cond-assign': _THROW.WARNING,
         // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
+        // Encourages using camelcase naming convention
+        'camelcase': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<camelcase>` : `severity: WARNING`

## Reason for addition/amendment
We should all be using CamelCase when defining new variables, It's good practice and looks cleaner than typing _ to separate words  in your code.

@netsells/frontend - Please review 