### PR TITLE
Adds no-console rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -481,6 +481,18 @@ if (error) {
 }
 ```
 
+#### 📍 no-console
+Disallows using the console in production.
+Will throw a warning if the node env is not set to production.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+if (error) {   
+    console.log(error);
+}
+```
+
 #### 📍 no-implicit-coercion
 Encourages stopping mixing different types of variables for the sake of cleaner and more readable code.
 

--- a/readme.md
+++ b/readme.md
@@ -469,6 +469,8 @@ if (additionalPosts.length) {
 }
 ```
 
+---
+
 #### 📍 no-alert
 Disallows using alert() function in production.
 Will throw a warning if the node env is not set to production (allows an alert-driven development).
@@ -481,6 +483,8 @@ if (error) {
 }
 ```
 
+---
+
 #### 📍 no-console
 Disallows using the console in production.
 Will throw a warning if the node env is not set to production.
@@ -492,6 +496,8 @@ if (error) {
     console.log(error);
 }
 ```
+
+---
 
 #### 📍 no-implicit-coercion
 Encourages stopping mixing different types of variables for the sake of cleaner and more readable code.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -54,6 +54,8 @@ module.exports = {
         'no-var': _THROW.ERROR,
         // Disallow alert() function in production, throw a warning in development
         'no-alert': Utils.isProduction() ? _THROW.ERROR : _THROW.WARNING,
+        // Disallow using the console in production, throw a warning in development
+        'no-console': Utils.isProduction() ? _THROW.ERROR : _THROW.WARNING,
         'dot-notation': _THROW.WARNING,
         // Discourage using confusing and sometimes unreadable JS tricks to do simple functions.
         'no-implicit-coercion': [_THROW.WARNING, {


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-console>` : `WARNING (dev), ERROR (production)`

## Reason for addition/amendment
Current linter throws an error when you use the console in your code (which in my personal opinion is an easy way to debug). This rule allows to use the console in development, but will throw an error in production.

@netsells/frontend - Please review 