### PR TITLE
Adds ‘prefer-const’ rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1444,6 +1444,49 @@ if (condition) {
 }
 ```
 
+#### 📍 prefer-const
+
+`@throws Warning`
+
+If a variable is set using 'let' and then never updated a warning will be issued as 'const' is preferred in this instance.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+let a = 3;
+console.log(a);
+
+let a;
+a = 1;
+return a;
+
+for (let i in [1, 2, 3]) {
+    console.log(i);
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+const a = 3;
+console.log(a);
+
+for (const i in [1, 2, 3]) {
+  console.log(i);
+}
+
+let a;
+a = 1;
+a = 2;
+return a;
+
+let a;
+if (true) {
+    a = 1;
+}
+
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/readme.md
+++ b/readme.md
@@ -1406,6 +1406,8 @@ foo(() => {
 });
 ```
 
+---
+
 #### 📍 no-lonely-if
 
 `@throws Warning`
@@ -1443,6 +1445,8 @@ if (condition) {
     // ...
 }
 ```
+
+---
 
 #### 📍 prefer-const
 

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -89,5 +89,7 @@ module.exports = {
         'no-cond-assign': _THROW.WARNING,
         // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
+        // Flags variables that are defined using 'let' but then never reassigned
+        'prefer-const': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<prefer-const>` : `severity: Warning`

## Reason for addition/amendment
>Will throw an error if 'let' is used and the variable is then never reassigned (in which instance 'const' would be the preferred variable type.
>See detailed examples in readme.md

@netsells/frontend - Please review 