### PR TITLE
Adds no-restricted-imports for lodash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -597,6 +597,22 @@ const b = 'Hello';
 const c = foo[b];
 ```
 
+#### 📍 no-restricted-imports
+
+Disallows importing lodash - people should import only the lodash sub-modules they need.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+import _ from 'lodash';
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+import flatten from 'lodash/flatten';
+```
+
 ---
 
 ### Vue

--- a/readme.md
+++ b/readme.md
@@ -597,6 +597,8 @@ const b = 'Hello';
 const c = foo[b];
 ```
 
+---
+
 #### 📍 no-restricted-imports
 
 Disallows importing lodash - people should import only the lodash sub-modules they need.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -90,6 +90,6 @@ module.exports = {
         // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
         // Disallows importing lodash
-        'no-restricted-imports': ['error', 'lodash']
+        'no-restricted-imports': ['error', 'lodash'],
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -89,7 +89,7 @@ module.exports = {
         'no-cond-assign': _THROW.WARNING,
         // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
-        // Disallows importing the lodash
+        // Disallows importing lodash
         'no-restricted-imports': ['error', 'lodash']
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -89,5 +89,7 @@ module.exports = {
         'no-cond-assign': _THROW.WARNING,
         // Forces use of ES6 arrow function expressions
         'prefer-arrow-callback': _THROW.ERROR,
+        // Disallows importing the lodash
+        'no-restricted-imports': ['error', 'lodash']
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-restricted-imports>` : `severity: ERROR`

## Reason for addition/amendment
Disallows importing the lodash module - we should import only the lodash submodules we actually need in our code.

@netsells/frontend - Please review 