### PR TITLE
adds readme instructions to add a pre-commit linter hook

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,13 @@ Add the loader into your workflow. The following example will force the linter t
 },
 ```
 
+If this doesn't run straight away, you may need to fix the permissions of the hook file:
+
+```bash
+chmod +x .git/hooks/pre-commit
+
+```
+
 ### To add pre commit linter
 
 This will run the git pre-commit hook which will run a linter before you commit to the project. Meaning all commited code should be nice and linted.

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,18 @@ Add the loader into your workflow. The following example will force the linter t
 },
 ```
 
+### To add pre commit linter
+
+This will run the git pre-commit hook which will run a linter before you commit to the project. Meaning all commited code should be nice and linted.
+
+```js
+
+    // .git/hooks/pre-commit
+
+    npm run lint
+
+```
+
 ## Rules
 
 ### JavaScript


### PR DESCRIPTION
## Suggested rule/changes(s):
N/A

## Reason for addition/amendment
Adds instructions in the readme to create a pre-commit hook that will lint the linter before commiting.

@netsells/frontend - Please review

Closes #52 