### PR TITLE
add-global-default adds default to list of global method ignores

### DIFF
--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -25,8 +25,8 @@ module.exports = {
                 ArrowFunctionExpression: true,
                 FunctionExpression: true,
             },
-            // Ignore all the standard VueJS lifecycle methods
             ignore: [
+                // Ignore all the standard VueJS lifecycle methods
                 'beforeCreate',
                 'created',
                 'beforeMount',
@@ -36,6 +36,9 @@ module.exports = {
                 'beforeUpdate',
                 'updated',
                 'data',
+
+                // Ignore the vue default prop method
+                'default',
             ],
         }],
         // Require jsdoc data to be consistently valid


### PR DESCRIPTION
## Suggested changes(s):
* `require-jsdoc-except/require-jsdoc`

## Reason for addition/amendment
Adds the method 'default' to the list of methods for jsdoc to ignore. As Vue prop declaration [now requires at least a type](https://github.com/netsells/eslint-config-netsells/commit/5204a7ad09e38eef7448219275203c8175631ccd#diff-a23ba9fdcadf5af6821ad74b551e795f) and more often than not, a default value, it can seem redundant to add a jsdoc for each call of "default()" on each prop in a component. 

This feels redundant as most props are or should be fairly self-explanatory and should be able to be rationalised just by skimming the component in most cases. Similarly the implementation of this method will never change as it will never have any arguments and only will return a simple value.

@netsells/frontend - Please review 