### PR TITLE
changes vue/html-index to warning from error

### DIFF
--- a/rules/vue.js
+++ b/rules/vue.js
@@ -30,7 +30,7 @@ module.exports = {
             ],
         }],
         // Enforce 4 space continuous indentation
-        'vue/html-indent': [_THROW.ERROR, 4, {
+        'vue/html-indent': [_THROW.WARNING, 4, {
             attribute: 1,
             closeBracket: 0,
         }],


### PR DESCRIPTION
## Suggested changes(s):
* `vue/indent-html` : `severity: WARNING`

## Reason for addition/amendment
Changes `vue/indent-html` to a `WARNING` rather than an `ERROR` for better commenting during development.

@netsells/frontend - Please review 