### PR TITLE
Adds javascript quotes rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1551,6 +1551,28 @@ if (true) {
 
 ```
 
+---
+
+#### 📍 quotes
+
+`@throws Warning`
+
+Limits the use of string quotes within JavaScript to 'single' quotation marks.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+const double = "double";
+const escaped = "a string with escaped 'single' quotes"
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+const single = 'single';
+const backtick = `back${x}tick`;
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -100,5 +100,7 @@ module.exports = {
         'no-duplicate-imports': _THROW.WARNING,
         // Disallows importing lodash
         'no-restricted-imports': ['error', 'lodash'],
+        // Enforce the use of single quotes when using JavaScript
+        'quotes': ['warning', 'single'],
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<quotes>` : `severity: WARNING`

## Reason for addition/amendment
>*Limits our use of quotation marks within javascript to 'single' quotes instead of "double" quotes or `backticks`*
>*`backticks` remain allowed in interpolation

@netsells/frontend - Please review 