### PR TITLE
Adds javascript key-spacing rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1551,6 +1551,32 @@ if (true) {
 
 ```
 
+---
+
+#### 📍 key-spacing
+
+`@throws Warning`
+
+Enforces a space after the colon in object literals.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+const object = {
+ 'key':'value',
+ 'key' :'value',   
+ 'key' : 'value',   
+};
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+const object = {
+ 'key': 'value',
+};
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -100,5 +100,7 @@ module.exports = {
         'no-duplicate-imports': _THROW.WARNING,
         // Disallows importing lodash
         'no-restricted-imports': ['error', 'lodash'],
+        // Enforces spacing around the colon in object literal properties
+        'key-spacing': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<key-spacing>` : `severity: WARNING`

## Reason for addition/amendment
>*Enforces correct spacing in object literals*
>*See updated readme for examples of incorrect useage*
>*Correct usage is `const obj = { 'key': 'value' };`

@netsells/frontend - Please review 