### PR TITLE
Vue/add no textarea mustache

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1599,6 +1599,28 @@ const single = 'single';
 const backtick = `back${x}tick`;
 ```
 
+---
+
+#### 📍 no-textarea-mustache
+
+`@throws Warning`
+
+Prevents the use of moustaches within textarea form fields.
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+<textarea>{{ message }}</textarea>
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+<textarea v-model="message" />
+```
+
+---
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/readme.md
+++ b/readme.md
@@ -1605,7 +1605,7 @@ const backtick = `back${x}tick`;
 
 `@throws Warning`
 
-Prevents the use of moustaches within textarea form fields.
+Prevents the use of mustaches within textarea form fields.
 
 ##### ❌ Example of incorrect code for this rule:
 

--- a/rules/vue.js
+++ b/rules/vue.js
@@ -73,5 +73,7 @@ module.exports = {
         'vue/no-unused-vars': [_THROW.ERROR],
         // When using the data property on a component (i.e. anywhere except on new Vue), the value must be a function that returns an object.
         'vue/no-shared-component-data': [_THROW.ERROR],
+        // Disallows the use of mustaches within textareas
+        'vue/no-textarea-mustache': [_THROW.WARNING],
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-textarea-mustache>` : `severity: WARNING`

## Reason for addition/amendment
>Prevents the use of moustaches within textarea form components.
>Instead enforces the use of v-model on said components

@netsells/frontend - Please review 