### PR TITLE
Adds no-unneeded-ternary rule

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1599,6 +1599,29 @@ const single = 'single';
 const backtick = `back${x}tick`;
 ```
 
+---
+
+#### 📍 no-unneeded-ternary
+
+`@throws Warning`
+
+Disallows the use of ternary operators when simpler alternatives exist
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+const a = x === 2 ? true : false;
+const b = x ? true : false;
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+const a = x === 2 ? 'yes' : 'No';
+const a = x !== false;
+const a = x ? 'Yes' : 'No';
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -88,7 +88,7 @@ module.exports = {
         'curly': _THROW.WARNING,
         // Encourage using template literals instead of '+' operator on strings
         'prefer-template': _THROW.WARNING,
-        //  discourage if statements as the only statement in else blocks
+        // discourage if statements as the only statement in else blocks
         'no-lonely-if': _THROW.WARNING,
         // Discourage conditional assignment of variables
         'no-cond-assign': _THROW.WARNING,
@@ -104,5 +104,7 @@ module.exports = {
         'key-spacing': _THROW.WARNING,
         // Enforce the use of single quotes when using JavaScript
         'quotes': [_THROW.WARNING, 'single'],
+        // Disallows ternary operators when simpler alternatives exist
+        'no-unneeded-ternary': [_THROW.WARNING],
     },
 }

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -105,6 +105,6 @@ module.exports = {
         // Enforce the use of single quotes when using JavaScript
         'quotes': [_THROW.WARNING, 'single'],
         // Disallows ternary operators when simpler alternatives exist
-        'no-unneeded-ternary': [_THROW.WARNING],
+        'no-unneeded-ternary': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-unneeded-ternary>` : `severity: WARNING`

## Reason for addition/amendment
>Prevents the use of ternary operators when there is a simpler alternative available

@netsells/frontend - Please review 