### PR TITLE
add no-debugger rule - Warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1622,6 +1622,31 @@ const array = [ 'red', 'green' ];
 const array = new Array(23);
 ```
 
+---
+
+#### 📍 debugger
+
+`@throws Warning`
+
+Disallows Debugger statements
+
+##### ❌ Example of incorrect code for this rule:
+
+```js
+function isTruthy(x) {
+    debugger;
+    return Boolean(x);
+}
+```
+
+##### ✅ Example of correct code for this rule:
+
+```js
+function isTruthy(x) {
+    return Boolean(x); // set a breakpoint at this line
+}
+```
+
 ## Contributing
 
 If you disagree with any rules in this linter, or feel additional rules should be added, please open an issue on this project to initiate an open dialogue with all team members. Please bear in mind this is a public repository.

--- a/rules/javascript.js
+++ b/rules/javascript.js
@@ -106,5 +106,7 @@ module.exports = {
         'quotes': [_THROW.WARNING, 'single'],
         // Disallows array literals with empty slots
         'no-sparse-arrays': _THROW.WARNING,
+        // Disallows debugger statements
+        'no-debugger': _THROW.WARNING,
     },
 }


### PR DESCRIPTION
## Suggested rule/changes(s):
* `<no-debugger>` : `severity: WARNING`

## Reason for addition/amendment
> currently this is set as an error in the default rules. 
>its doing my head in

@netsells/frontend - Please review 